### PR TITLE
Fix Error uninitialized constant ForemanChef::Engine::ForemanTasks

### DIFF
--- a/lib/foreman_chef/engine.rb
+++ b/lib/foreman_chef/engine.rb
@@ -1,4 +1,5 @@
 require 'deface'
+require 'foreman_tasks'
 
 module ForemanChef
   #Inherit from the Rails module of the parent app (Foreman), not the plugin.


### PR DESCRIPTION

**I have not fully tested this... I just used some intuition and guessed to see if I could fix the error**

Fixes a fatal error preventing foreman from starting: uninitialized constant ForemanChef::Engine::ForemanTasks (NameError)

Full Stack Trace

```
/usr/share/foreman/vendor/ruby/1.9.1/gems/foreman_chef-0.1.3/lib/foreman_chef/engine.rb:23:in `block in <class:Engine>': uninitialized constant ForemanChef::Engine::ForemanTasks (NameError)
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/initializable.rb:30:in `instance_exec'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/initializable.rb:30:in `run'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/initializable.rb:55:in `block in run_initializers'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/initializable.rb:54:in `each'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/initializable.rb:54:in `run_initializers'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/application.rb:136:in `initialize!'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/railtie/configurable.rb:30:in `method_missing'
        from /usr/share/foreman/config/environment.rb:12:in `<top (required)>'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
        from /usr/share/foreman/config.ru:3:in `block in <main>'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/builder.rb:51:in `instance_eval'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/builder.rb:51:in `initialize'
        from /usr/share/foreman/config.ru:in `new'
        from /usr/share/foreman/config.ru:in `<main>'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/builder.rb:40:in `eval'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/builder.rb:40:in `parse_file'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/server.rb:200:in `app'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/commands/server.rb:46:in `app'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/server.rb:304:in `wrapped_app'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/rack-1.4.5/lib/rack/server.rb:254:in `start'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/commands/server.rb:70:in `start'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/commands.rb:55:in `block in <top (required)>'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/commands.rb:50:in `tap'
        from /usr/share/foreman/vendor/ruby/1.9.1/gems/railties-3.2.21/lib/rails/commands.rb:50:in `<top (required)>'
        from script/rails:6:in `require'
        from script/rails:6:in `<main>'
```


