### PR TITLE
restrict deface versions

### DIFF
--- a/foreman_chef.gemspec
+++ b/foreman_chef.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 3.2.8"
-  s.add_dependency "deface"
+  s.add_dependency "deface", "< 1.0"
   s.add_dependency "foreman-tasks", '~> 0.6.9'
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Deface was pinned to <1.0 over all Foreman projects for Ruby 1.8 compatibility and until now nobody did take the step to get to the higher version with a slighly different syntax. Maybe this would be a good point for all Foreman 1.9 plugins, but for now just unify it also here.