### PR TITLE
Fixes #8966, #14547 - manage clients on chef-server

### DIFF
--- a/app/lib/actions/foreman_chef/client/create.rb
+++ b/app/lib/actions/foreman_chef/client/create.rb
@@ -1,0 +1,36 @@
+module Actions
+  module ForemanChef
+    module Client
+      class Create < Actions::EntryAction
+
+        def plan(name, proxy)
+          client_exists_in_chef = proxy.show_client(name)
+          if client_exists_in_chef
+            raise ::ForemanChef::ObjectExistsException.new(N_('Client with name %s already exist on this Chef proxy' % name))
+          else
+            plan_self :chef_proxy_id => proxy.id, :name => name
+          end
+        rescue => e
+          Rails.logger.debug "Unable to communicate with Chef proxy, #{e.message}"
+          Rails.logger.debug e.backtrace.join("\n")
+          raise ::ForemanChef::ProxyException.new(N_('CLIENT Unable to communicate with Chef proxy, %s' % e.message))
+        end
+
+        def run
+          proxy = ::SmartProxy.find_by_id(input[:chef_proxy_id])
+          action_logger.debug "Creating client #{input[:name]} on proxy #{proxy.name} at #{proxy.url}"
+          self.output = proxy.create_client(input[:name])
+        end
+
+        def humanized_name
+          _("Create client")
+        end
+
+        def humanized_input
+          input[:name]
+        end
+      end
+    end
+  end
+end
+

--- a/app/lib/actions/foreman_chef/host/create.rb
+++ b/app/lib/actions/foreman_chef/host/create.rb
@@ -1,0 +1,51 @@
+module Actions
+  module ForemanChef
+    module Host
+      class Create < Actions::EntryAction
+
+        def plan(host)
+          action_subject(host)
+
+          if host.chef_proxy
+            client_exists_in_chef = host.chef_proxy.show_client(host.name)
+
+            sequence do
+              if client_exists_in_chef
+                plan_action Actions::ForemanChef::Client::Destroy, host.name, host.chef_proxy
+              end
+
+              unless ::Setting::ForemanChef.validate_bootstrap_method
+                client_creation = plan_action Actions::ForemanChef::Client::Create, host.name, host.chef_proxy
+              end
+
+              plan_self(:create_action_output => client_creation.output)
+            end
+          end
+        rescue => e
+          Rails.logger.debug "Unable to communicate with Chef proxy, #{e.message}"
+          Rails.logger.debug e.backtrace.join("\n")
+          raise ::ForemanChef::ProxyException.new(N_('Unable to communicate with Chef proxy, %s' % e.message))
+        end
+
+        # def run
+        #   # TODO create node with runlist?
+        # end
+
+        def finalize
+          if input[:create_action_output][:private_key].present?
+            ::Host.find(self.input[:host][:id]).update_attribute(:chef_private_key, input[:create_action_output][:private_key])
+          end
+        end
+
+        def humanized_name
+          _("Create node")
+        end
+
+        def humanized_input
+          input[:host][:name]
+        end
+      end
+    end
+  end
+end
+

--- a/app/lib/actions/foreman_chef/host/destroy.rb
+++ b/app/lib/actions/foreman_chef/host/destroy.rb
@@ -7,7 +7,7 @@ module Actions
 
         def plan(host)
           action_subject(host)
-          if (::Setting::ForemanChef.auto_deletion && proxy = ::SmartProxy.find_by_id(host.chef_proxy_id))
+          if (::Setting::ForemanChef.auto_deletion && proxy = host.chef_proxy)
             node_exists_in_chef = proxy.show_node(host.name)
             if node_exists_in_chef
               plan_self :chef_proxy_id => host.chef_proxy_id

--- a/app/lib/proxy_api/foreman_chef/chef_proxy.rb
+++ b/app/lib/proxy_api/foreman_chef/chef_proxy.rb
@@ -43,14 +43,21 @@ module ProxyAPI
       end
 
       # Shows a Chef Client entry
-      # [+key+] : String containing the hostname
-      # Returns : Hash representation of host on chef server
+      # [+key+] : String containing the client name
+      # Returns : Hash representation of client on chef server
       def show_client(key)
         Client.new(@args).send(:get, key)
       end
 
+      # Creates a Chef Client entry
+      # [+key+] : String containing the client name
+      # Returns : Hash representation of client on chef server
+      def create_client(key)
+        Client.new(@args).send(:post, :client => {:name => key})
+      end
+
       # Deletes a Chef Client entry
-      # [+key+] : String containing the hostname
+      # [+key+] : String containing the client name
       # Returns : Boolean status
       def delete_client(key)
         Client.new(@args).send(:delete, key)

--- a/app/models/foreman_chef/concerns/host_action_subject.rb
+++ b/app/models/foreman_chef/concerns/host_action_subject.rb
@@ -5,6 +5,11 @@ module ForemanChef
       include ForemanTasks::Concerns::ActionSubject
       include ForemanTasks::Concerns::ActionTriggering
 
+      def create_action
+        sync_action!
+        ::Actions::ForemanChef::Host::Create
+      end
+
       def destroy_action
         sync_action!
         ::Actions::ForemanChef::Host::Destroy
@@ -18,5 +23,5 @@ module ForemanChef
 end
 
 class ::Host::Managed::Jail < Safemode::Jail
-  allow :chef_proxy, :chef_environment
+  allow :chef_proxy, :chef_environment, :chef_private_key
 end

--- a/app/models/foreman_chef/concerns/host_build.rb
+++ b/app/models/foreman_chef/concerns/host_build.rb
@@ -1,0 +1,14 @@
+module ForemanChef
+  module Concerns
+    module HostBuild
+      extend ActiveSupport::Concern
+      included do
+        include ForemanTasks::Concerns::ActionSubject
+        include ForemanTasks::Concerns::ActionTriggering
+
+        after_build :plan_destroy_action
+      end
+
+    end
+  end
+end

--- a/app/models/foreman_chef/concerns/host_extensions.rb
+++ b/app/models/foreman_chef/concerns/host_extensions.rb
@@ -5,6 +5,7 @@ module ForemanChef
 
       included do
         alias_method_chain :set_hostgroup_defaults, :chef_attributes
+        attr_accessible :chef_private_key
       end
 
       def set_hostgroup_defaults_with_chef_attributes

--- a/app/models/foreman_chef/concerns/renderer.rb
+++ b/app/models/foreman_chef/concerns/renderer.rb
@@ -9,6 +9,10 @@ module ForemanChef
         raise SecurityError, 'snippet contains not white-listed characters' unless snippet_name =~ /\A[a-zA-Z0-9 _-]+\Z/
         snippet snippet_name
       end
+
+      def validation_bootstrap_method?
+        ::Setting::ForemanChef.validate_bootstrap_method
+      end
     end
   end
 end

--- a/app/models/foreman_chef/concerns/smart_proxy_extensions.rb
+++ b/app/models/foreman_chef/concerns/smart_proxy_extensions.rb
@@ -32,6 +32,13 @@ module ForemanChef
         return false
       end
 
+      def create_client(fqdn)
+        begin
+          reply = ProxyAPI::ForemanChef::ChefProxy.new(:url => url).create_client(fqdn)
+          JSON.parse(reply)
+        end
+      end
+
       def delete_client(fqdn)
         begin
           reply = ProxyAPI::ForemanChef::ChefProxy.new(:url => url).delete_client(fqdn)

--- a/app/models/setting/foreman_chef.rb
+++ b/app/models/setting/foreman_chef.rb
@@ -6,7 +6,8 @@ class Setting::ForemanChef < Setting
 
     self.transaction do
       [
-          self.set('auto_deletion', N_("Enable the auto deletion of mapped objects in chef-server through foreman-proxy (currently node and client upon host deletion)"), true),
+          self.set('auto_deletion', N_("Enable the auto deletion of mapped objects in chef-server through foreman-proxy (currently node and client upon host deletion, client on host rebuild)"), true),
+          self.set('validation_bootstrap_method', N_("Use validation.pem or create client directly storing private key in Foreman DB)"), true),
       ].each { |s| self.create! s.update(:category => "Setting::ForemanChef")}
     end
 

--- a/app/services/foreman_chef/object_exists_exception.rb
+++ b/app/services/foreman_chef/object_exists_exception.rb
@@ -1,0 +1,4 @@
+module ForemanChef
+  class ObjectExistsException < Foreman::Exception
+  end
+end

--- a/app/views/foreman/unattended/snippets/_chef_client_bootstrap.erb
+++ b/app/views/foreman/unattended/snippets/_chef_client_bootstrap.erb
@@ -1,12 +1,17 @@
+<% if validation_bootstrap_method? -%>
 echo "Creating validation.pem"
 mkdir /etc/chef
 touch /etc/chef/validation.pem
 chmod 600 /etc/chef/validation.pem
 
-## You need to paste here foreman's private key
 cat << 'EOF' > /etc/chef/validation.pem
 <%= @host.params['chef_validation_private_key'] %>
 EOF
+<% else -%>
+cat << 'EOF' > /etc/chef/client.pem
+<%= @host.chef_private_key %>
+EOF
+<% end -%>
 
 ## If chef_server_certificate is present, install it into /etc/chef/trusted_certs
 <% chef_server_certificate = @host.params['chef_server_certificate'] -%>

--- a/db/migrate/20160408091653_add_chef_private_key_to_host.rb
+++ b/db/migrate/20160408091653_add_chef_private_key_to_host.rb
@@ -1,0 +1,5 @@
+class AddChefPrivateKeyToHost < ActiveRecord::Migration
+  def change
+    add_column :hosts, :chef_private_key, :text
+  end
+end

--- a/lib/foreman_chef/engine.rb
+++ b/lib/foreman_chef/engine.rb
@@ -48,7 +48,7 @@ module ForemanChef
     initializer 'foreman_chef.register_plugin', :after => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_chef do
         requires_foreman '>= 1.11'
-        allowed_template_helpers :chef_bootstrap
+        allowed_template_helpers :chef_bootstrap, :validation_bootstrap_method?
 
         permission :import_chef_environments, { :environments => [:import, :synchronize] }, :resource_type => 'ForemanChef::Environment'
         permission :view_chef_environments, { :environments => [:index, :environments_for_chef_proxy] }, :resource_type => 'ForemanChef::Environment'
@@ -85,6 +85,7 @@ module ForemanChef
       ::Hostgroup.send :include, ForemanChef::Concerns::HostgroupExtensions
       ::SmartProxy.send :include, ForemanChef::Concerns::SmartProxyExtensions
       ::Host::Base.send :include, ForemanChef::Concerns::HostActionSubject
+      ::Host::Managed.send :include, ForemanChef::Concerns::HostBuild
       ::HostsController.send :include, ForemanChef::Concerns::HostsControllerRescuer
       # Renderer Concern needs to be injected to controllers, ForemanRenderer was already included
       (TemplatesController.descendants + [TemplatesController]).each do |klass|


### PR DESCRIPTION
When host is rebuilt a client is deleted on chef-server so new private
key can be generated using validation.pem

Selected chef environment is set for a client via provisioning template.

Optional Foreman can create client for host directly so no
validation.pem is used. A bootstrap method is set via new setting called
validation_bootstrap_method.