### PR TITLE
Fixes #16127 - Bumping up the foreman-tasks requirement

### DIFF
--- a/foreman_chef.gemspec
+++ b/foreman_chef.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "deface"
-  s.add_dependency "foreman-tasks", '>= 0.6.9', '< 0.8.0'
+  s.add_dependency "foreman-tasks", '>= 0.8.0'
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Per https://github.com/theforeman/foreman-packaging/pull/1265#issuecomment-240021610, we need to bump the foreman-tasks requirement to support foreman-tasks 0.8.0. Let me know if you'd prefer that I use a different requirement like `'>= 0.6.9', '< 0.9.0'`.