### PR TITLE
Fixes #24888 - fix prepending ActionSubject

### DIFF
--- a/app/models/foreman_chef/concerns/host_action_subject.rb
+++ b/app/models/foreman_chef/concerns/host_action_subject.rb
@@ -1,11 +1,6 @@
 module ForemanChef
   module Concerns
     module HostActionSubject
-      def self.prepended(base)
-        base.send :prepend, ForemanTasks::Concerns::ActionSubject
-        base.send :prepend, ForemanTasks::Concerns::ActionTriggering
-      end
-
       def update_action
         sync_action!
         ::Actions::ForemanChef::Host::Update

--- a/app/models/foreman_chef/concerns/host_build.rb
+++ b/app/models/foreman_chef/concerns/host_build.rb
@@ -2,9 +2,6 @@ module ForemanChef
   module Concerns
     module HostBuild
       def self.prepended(base)
-        base.send :prepend, ForemanTasks::Concerns::ActionSubject
-        base.send :prepend, ForemanTasks::Concerns::ActionTriggering
-
         base.after_build do |host|
           ::ForemanTasks.sync_task ::Actions::ForemanChef::Client::Destroy, host.name, host.chef_proxy
           # private key is no longer valid

--- a/lib/foreman_chef/engine.rb
+++ b/lib/foreman_chef/engine.rb
@@ -88,6 +88,8 @@ module ForemanChef
 
       ::Host::Managed.send :include, ForemanChef::Concerns::HostAndHostgroupExtensions
       ::Hostgroup.send :include, ForemanChef::Concerns::HostAndHostgroupExtensions
+      ::Host::Managed.send :prepend, ForemanTasks::Concerns::ActionSubject
+      ::Host::Managed.send :prepend, ForemanTasks::Concerns::ActionTriggering
       ::Host::Managed.send :prepend, ForemanChef::Concerns::HostExtensions
       ::Hostgroup.send :include, ForemanChef::Concerns::HostgroupExtensions
       ::SmartProxy.send :prepend, ForemanChef::Concerns::SmartProxyExtensions


### PR DESCRIPTION
The foreman-tasks' version needs to be prepended before the Chef's one. Otherwise the `action_input_key` is not overridden properly.